### PR TITLE
docs: improve dev setup and add start_dev.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,33 +4,74 @@ Vehicle fleet management for social associations. Tracks vehicles, beneficiaries
 
 ## Development
 
-### Backend
+### Quick start
+
+**1. Backend** — from the repo root:
 
 ```bash
+source .venv/bin/activate
 cd backend
-# copy .env-template to .env and fill in values (DB_TYPE=sqlite works locally)
+# First time only: copy the template (DB_TYPE=sqlite works locally, SECRET_KEY can be anything)
+cp .env-template .env
+# Edit .env: set SECRET_KEY=any-random-string, DB_TYPE=sqlite, DB_ADDR=db.sqlite3
 python manage.py migrate
 python manage.py runserver
+# Backend runs on http://localhost:8000
 ```
 
+**2. Default dev user** — run once after the first migrate:
+
 ```bash
+source .venv/bin/activate
+cd backend
+python manage.py shell -c "
+from django.contrib.auth import get_user_model
+from core.models import Action
+U = get_user_model()
+action, _ = Action.objects.get_or_create(name='Default')
+u = U.objects.create_superuser('admin', 'admin@example.com', 'admin')
+u.actions.add(action); u.current_action = action; u.save()
+print('Created admin@example.com / admin')
+"
+```
+
+**3. Frontend** — in a second terminal:
+
+```bash
+cd frontend
+# First time only:
+npm install
+# Create .env pointing to the backend (already gitignored):
+echo 'BASE_URL=http://localhost:8000' > .env
+npm run dev
+# Frontend runs on http://localhost:5173
+```
+
+Login at `http://localhost:5173` with **admin@example.com / admin**.
+
+Or use the helper script to start both servers at once:
+
+```bash
+./start_dev.sh
+```
+
+---
+
+### Backend commands
+
+```bash
+source .venv/bin/activate && cd backend
 python manage.py test                                        # all tests
 python manage.py test api.tests.MyTestClass.my_test_method  # single test
 python manage.py spectacular --file schema.yml               # regenerate OpenAPI schema
 ```
 
-### Frontend
+### Frontend commands
 
 ```bash
 cd frontend
-npm install
-npm run dev   # dev server, proxies /api to localhost:8000
 npm run build
-```
-
-Regenerate TypeScript types after backend schema changes:
-```bash
-npx openapi-typescript ../backend/schema.yml -o src/types/schema.d.ts
+npx openapi-typescript ../backend/schema.yml -o src/types/schema.d.ts  # regen types after schema changes
 ```
 
 ### Full stack (Docker)

--- a/start_dev.sh
+++ b/start_dev.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -e
+
+ROOT="$(cd "$(dirname "$0")" && pwd)"
+
+cleanup() {
+    echo ""
+    echo "Stopping dev servers..."
+    kill "$BACKEND_PID" "$FRONTEND_PID" 2>/dev/null
+    wait "$BACKEND_PID" "$FRONTEND_PID" 2>/dev/null
+    exit 0
+}
+trap cleanup INT TERM
+
+source "$ROOT/.venv/bin/activate"
+
+echo "Starting backend on http://localhost:8000 ..."
+(cd "$ROOT/backend" && python manage.py runserver) &
+BACKEND_PID=$!
+
+echo "Starting frontend on http://localhost:5173 ..."
+(cd "$ROOT/frontend" && npm run dev) &
+FRONTEND_PID=$!
+
+wait "$BACKEND_PID" "$FRONTEND_PID"


### PR DESCRIPTION
## Summary

- Rewrites the README dev setup section with complete, working step-by-step instructions (venv activation, `.env` creation, default user seeding)
- Documents that `frontend/.env` with `BASE_URL=http://localhost:8000` is required for the frontend to reach the backend (CORS is already configured on the Django side)
- Adds `start_dev.sh` helper script at the repo root to start both backend and frontend servers with a single command, with clean Ctrl+C shutdown

## Test plan

- [ ] Fresh clone: follow README steps 1–3, confirm login works at `http://localhost:5173`
- [ ] `./start_dev.sh` starts both servers and Ctrl+C stops both cleanly