### PR TITLE
feat: address autocomplete for beneficiary form

### DIFF
--- a/frontend/src/components/beneficiary/AddressAutocomplete.tsx
+++ b/frontend/src/components/beneficiary/AddressAutocomplete.tsx
@@ -1,0 +1,109 @@
+import React, {useEffect, useRef, useState} from "react";
+import {Autocomplete, AutocompleteProps, Loader} from "@mantine/core";
+import {useDebouncedValue} from "@mantine/hooks";
+import {DEBOUNCE_TIME} from "../../constants";
+
+const BAN_API = "https://api-adresse.data.gouv.fr/search/";
+
+interface BanAddressFeature {
+    properties: {
+        label: string;
+        name: string;
+        postcode: string;
+        city: string;
+    };
+}
+
+interface BanApiResponse {
+    features: BanAddressFeature[];
+}
+
+export interface AddressSelection {
+    name: string;
+    city: string;
+    postcode: string;
+}
+
+interface AddressAutocompleteProps extends Omit<AutocompleteProps, "data" | "onOptionSubmit"> {
+    onAddressSelect?: (addr: AddressSelection) => void;
+}
+
+const AddressAutocomplete: React.FC<AddressAutocompleteProps> = ({
+    value,
+    onChange,
+    onAddressSelect,
+    ...rest
+}) => {
+    const [query, setQuery] = useState(value ?? "");
+    const [debouncedQuery] = useDebouncedValue(query, DEBOUNCE_TIME);
+    const [features, setFeatures] = useState<BanAddressFeature[]>([]);
+    const [isFetching, setIsFetching] = useState(false);
+    // Mantine fires onChange after onOptionSubmit with the full label — this ref suppresses that call.
+    const skipNextChangeRef = useRef(false);
+
+    useEffect(() => {
+        setQuery(value ?? "");
+    }, [value]);
+
+    useEffect(() => {
+        if (debouncedQuery.trim().length < 3) {
+            setFeatures([]);
+            return;
+        }
+
+        const controller = new AbortController();
+        setIsFetching(true);
+
+        fetch(`${BAN_API}?q=${encodeURIComponent(debouncedQuery)}&limit=5`, {
+            signal: controller.signal,
+        })
+            .then(r => r.json())
+            .then((data: BanApiResponse) => {
+                setFeatures(data.features);
+                setIsFetching(false);
+            })
+            .catch(err => {
+                if (err.name !== "AbortError") {
+                    setFeatures([]);
+                    setIsFetching(false);
+                }
+            });
+
+        return () => controller.abort();
+    }, [debouncedQuery]);
+
+    const suggestions = features.map(f => f.properties.label);
+
+    return (
+        <Autocomplete
+            {...rest}
+            value={query}
+            data={suggestions}
+            onChange={(val) => {
+                if (skipNextChangeRef.current) {
+                    skipNextChangeRef.current = false;
+                    return;
+                }
+                setQuery(val);
+                onChange?.(val);
+            }}
+            onOptionSubmit={(label) => {
+                const feature = features.find(f => f.properties.label === label);
+                if (!feature) return;
+                const streetValue = feature.properties.name;
+                skipNextChangeRef.current = true;
+                setQuery(streetValue);
+                onChange?.(streetValue);
+                onAddressSelect?.({
+                    name: streetValue,
+                    city: feature.properties.city,
+                    postcode: feature.properties.postcode,
+                });
+            }}
+            rightSection={isFetching ? <Loader size="xs" type="bars" /> : undefined}
+            filter={({ options }) => options}
+        />
+    );
+};
+
+export default AddressAutocomplete;

--- a/frontend/src/components/beneficiary/BeneficiaryModal.tsx
+++ b/frontend/src/components/beneficiary/BeneficiaryModal.tsx
@@ -5,6 +5,7 @@ import {BeneficiaryWritableFields} from "../../types/beneficiary";
 import {Box, Group, LoadingOverlay, Modal, TextInput} from "@mantine/core";
 import {DateInput, DateValue} from "@mantine/dates";
 import dayjs from "dayjs";
+import AddressAutocomplete from "./AddressAutocomplete";
 
 
 
@@ -12,6 +13,7 @@ const BeneficiaryModal: React.FC<
   UseModalFormReturnType<BaseRecord, HttpError, BeneficiaryWritableFields>
 > = ({
     getInputProps,
+    setFieldValue,
     errors,
     modal: { visible, close, title },
     saveButtonProps,
@@ -39,7 +41,16 @@ const BeneficiaryModal: React.FC<
              <LoadingOverlay visible={refineCore.formLoading} overlayProps={{blur:2}} />
             <TextInput label="Prénom" {...getInputProps("first_name")} error={errors.first_name} withAsterisk/>
             <TextInput label="Nom" {...getInputProps("last_name")} error={errors.last_name} withAsterisk/>
-            <TextInput label="Adresse" {...getInputProps("address")} error={errors.address} withAsterisk/>
+            <AddressAutocomplete
+                label="Adresse"
+                {...getInputProps("address")}
+                error={errors.address}
+                withAsterisk
+                onAddressSelect={({ name, city, postcode }) => {
+                    setFieldValue("city", city);
+                    setFieldValue("postal_code", postcode);
+                }}
+            />
             <TextInput label="Complement d'adresse" {...getInputProps("address_complement")} error={errors.adress_complement} />
 
             <Group>


### PR DESCRIPTION
## Summary

- Adds `AddressAutocomplete` component that fetches suggestions from the French government address API ([adresse.data.gouv.fr / BAN](https://adresse.data.gouv.fr/)) — free, no API key, CORS-enabled
- Replaces the plain `Adresse` TextInput in `BeneficiaryModal` with the new component
- Selecting a suggestion auto-fills the **Ville** and **Code postal** fields; both remain manually editable
- No backend changes — the BAN API is called directly from the browser

## How it works

- 300ms debounce before querying (reuses existing `DEBOUNCE_TIME` constant)
- Minimum 3 characters before fetching (avoids noise)
- `AbortController` cancels stale in-flight requests
- Stores only the street portion (`name`) in the `address` field, not the full label with city/postal
- Falls back to plain text input if the API is unavailable

## Test plan

- [x] Typing in the address field shows BAN API suggestions after 300ms
- [x] Selecting a suggestion fills address (street only), city, and postal code
- [x] City and postal code remain editable after auto-fill
- [x] Clearing the address field does not clear city/postal
- [x] Short queries (<3 chars) show no dropdown
- [x] Free-form input (no suggestion selected) still works and submits normally
- [x] Full form submission persists correct data to the backend
- [x] Edit modal pre-fills the stored street-only address without triggering API calls
- [x] Validation errors still fire correctly on empty address