### PR TITLE
fix: skip auto-pull of postgres image in CD

### DIFF
--- a/CD/docker-compose.yml
+++ b/CD/docker-compose.yml
@@ -40,6 +40,7 @@ services:
   postgres:
     container_name: "mobilite-db"
     image: bitnami/postgresql:14
+    pull_policy: never
     restart: unless-stopped
     networks:
       - mobilite-internal


### PR DESCRIPTION
## Problem

`bitnami/postgresql:14` was removed from Docker Hub. During deployment, `docker compose pull` tries to pull all services in parallel — when postgres fails with `manifest unknown`, the command exits before backend and nginx images finish pulling. `docker compose up -d` then sees the containers already running and does nothing, leaving production on the old version.

This is what broke the v1.9.0 deployment.

## Fix

Add `pull_policy: never` to the postgres service in `CD/docker-compose.yml`. The database image should never be auto-updated during deploys — the container on the server is already running correctly and we don't want uncontrolled DB upgrades. Any intentional postgres upgrade should be a deliberate manual operation.

## After merging

Re-trigger the deployment workflow (or re-publish the v1.9.0 release) to actually deploy v1.9.0 to production.