### PR TITLE
fix: pin backend to python:3.12 (hotfix)

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3 as base
+FROM python:3.12 as base
 WORKDIR /backend
 RUN apt-get update && apt-get install -y postgresql-client cron
 


### PR DESCRIPTION
## Problem

The v1.9.0 backend image was built with `FROM python:3` which resolved to Python **3.14** on the new build. Django 5.0.3 is only compatible with Python 3.10–3.12 and crashes on 3.14 with:

```
AttributeError: 'super' object has no attribute 'dicts'
Exception Location: django/template/context.py, line 39, in __copy__
```

This broke all Django admin pages in production immediately after the v1.9.0 deploy.

## Fix

Pin the base image to `python:3.12`.

## After merging

Need to delete and recreate the `v1.9.0` tag on master so the build pipeline runs again with the corrected Dockerfile.