### PR TITLE
fix: pass Sentry DSN and auth token to frontend build

### DIFF
--- a/.github/workflows/buildNpublish.yml
+++ b/.github/workflows/buildNpublish.yml
@@ -66,6 +66,8 @@ jobs:
           build-args: |
             BASE_URL=${{ env.BASE_URL }}
             VERSION=${{ env.VERSION }}
+            VITE_SENTRY_DSN=${{ secrets.VITE_SENTRY_DSN }}
+            SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}
           push: true
           tags: ${{ steps.meta_front.outputs.tags }}
           labels: ${{ steps.meta_front.outputs.labels }}

--- a/frontend/src/instrument.ts
+++ b/frontend/src/instrument.ts
@@ -8,7 +8,7 @@ import {
 } from "react-router-dom";
 
 Sentry.init({
-  dsn: import.meta.env.VITE_SENTRY_DSN,
+  dsn: process.env["VITE_SENTRY_DSN"],
   environment: import.meta.env.MODE,
   release: process.env["VERSION"] || "0.0.0-dev",
   integrations: [

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -6,6 +6,7 @@ import { sentryVitePlugin } from "@sentry/vite-plugin";
 const envAvailableKeys = [
     'BASE_URL',
     'VERSION',
+    'VITE_SENTRY_DSN',
     ];
 
 type processEnvKeys = typeof envAvailableKeys[number];


### PR DESCRIPTION
## Problem

Sentry is not working in production because `VITE_SENTRY_DSN` and `SENTRY_AUTH_TOKEN` were never passed to the Docker build — they were declared as `ARG` in the Dockerfile but omitted from the build workflow's `build-args`. As a result, Sentry initializes with `dsn: undefined` and silently drops all events.

Additionally, `instrument.ts` was reading the DSN via `import.meta.env.VITE_SENTRY_DSN` instead of the `process.env` mechanism used for `VERSION`, which is inconsistent with how `vite.config.ts` exposes build-time values.

## Fix

- Add `VITE_SENTRY_DSN` to `envAvailableKeys` in `vite.config.ts` so it's exposed via `process.env` like other build vars
- Update `instrument.ts` to use `process.env["VITE_SENTRY_DSN"]`
- Pass `VITE_SENTRY_DSN` and `SENTRY_AUTH_TOKEN` secrets as build args in `buildNpublish.yml`

## ⚠️ Server-side action also required

The Sentry tunnel at `/sentry-tunnel/` validates incoming events against `SENTRY_DSN` from the server's `.env` file. If that variable is not set on the production server, the tunnel returns 400 for every event even after this fix. Make sure `SENTRY_DSN=<your-dsn>` is in the server `.env`.