### PR TITLE
fix: correct closed contract label

### DIFF
--- a/frontend/src/components/contract/ContractStatusBadge.tsx
+++ b/frontend/src/components/contract/ContractStatusBadge.tsx
@@ -19,7 +19,7 @@ const ContractStatusBadge = ({contract}: {contract: CompleteContract}) => {
     const tooltipTextMap: Record<string, string> = {
         [ContractStatusEnum.waiting]: "En attente d'Etat des lieux",
         [ContractStatusEnum.pending]: "En cours: véhicule à disposition",
-        [ContractStatusEnum.over]: "Clôturer: véhicule rendu, contrat en attente de paiement",
+        [ContractStatusEnum.over]: "Clôturé: véhicule rendu, contrat en attente de paiement",
         [ContractStatusEnum.payed]: "Payé: contrat terminé",
     }
 

--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -37,7 +37,7 @@ export const contractReasonLabelMap: Record<string,string> = {
 export const contractStatusLabelMap: Record<string, string> = {
     [ContractStatusEnum.waiting]: "En attente d'EDL",
     [ContractStatusEnum.pending]: "En cours",
-    [ContractStatusEnum.over]: "Clôturer",
+    [ContractStatusEnum.over]: "Clôturé",
     [ContractStatusEnum.payed]: "Payé",
 }
 


### PR DESCRIPTION
## What changed

Corrects the label for closed contracts from the action verb `Clôturer` to the past-participle status `Clôturé` in the contract status map and tooltip text.

This keeps the status badge language consistent with issue #37: the contract has already been closed / vehicle returned, rather than asking the user to close it.

## Verification

- `cd frontend && npm ci`
- `cd frontend && npm run build`

Build completed successfully. It emitted existing Sentry auth-token and chunk-size warnings only.

Closes #37
