### PR TITLE
fix(frontend): pin Node to 24-alpine and fix TS build error

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,7 +1,7 @@
 # This Dockerfile uses `serve` npm package to serve the static files with node process.
 # You can find the Dockerfile for nginx in the following link:
 # https://github.com/refinedev/dockerfiles/blob/main/vite/Dockerfile.nginx
-FROM node:lts-alpine3.12 as base
+FROM node:24-alpine as base
 
 FROM base as deps
 WORKDIR /frontend

--- a/frontend/src/components/contract/ContractRenewalTimeline.tsx
+++ b/frontend/src/components/contract/ContractRenewalTimeline.tsx
@@ -42,7 +42,7 @@ function formatReferent(c: Contract): string {
 }
 
 function getDistance(c: Contract): string {
-    if (c.end_kilometer != null) return `${humanizeNumber(c.end_kilometer - c.start_kilometer)} km`;
+    if (c.end_kilometer != null) return `${humanizeNumber(c.end_kilometer - (c.start_kilometer ?? 0))} km`;
     if (c.max_kilometer != null) return `${humanizeNumber(c.max_kilometer)} km`;
     return "—";
 }
@@ -150,7 +150,7 @@ export default function ContractRenewalTimeline({contract}: {contract: Contract}
     events.sort((a, b) => dayjs(a.date).diff(dayjs(b.date)));
 
     const {totalKm, totalDue} = chain.reduce((acc, c) => ({
-        totalKm:  acc.totalKm + Math.max(0, c.end_kilometer != null ? c.end_kilometer - c.start_kilometer : (c.max_kilometer ?? 0)),
+        totalKm:  acc.totalKm + Math.max(0, c.end_kilometer != null ? c.end_kilometer - (c.start_kilometer ?? 0) : (c.max_kilometer ?? 0)),
         totalDue: acc.totalDue + (c.price - (c.discount ?? 0)),
     }), {totalKm: 0, totalDue: 0});
 


### PR DESCRIPTION
## Résumé

Le build Docker du frontend échouait :

- Le tag `node:lts-alpine3.12` était figé sur une image Node 16 en cache, incompatible avec les dépendances nécessitant Node >=18 (vite, vitest, glob, @sentry/*), causant des warnings puis un comportement instable.
- `ContractRenewalTimeline.tsx` avait une erreur TS18048 (`start_kilometer` possiblement `undefined`) qui bloquait `tsc` avant le build vite.

## Changements
- `frontend/Dockerfile` : pin explicite sur `node:24-alpine` (LTS active)
- `frontend/src/components/contract/ContractRenewalTimeline.tsx` : fallback `?? 0` sur `start_kilometer`

## Test plan
- [x] `docker build` du frontend passe (testé localement)
- [ ] Vérifier l'affichage de la frise de renouvellement en prod après déploiement