### PR TITLE
fix(sentry): contexte utilisateur + baisse du taux d'échantillonnage replay

### DIFF
--- a/frontend/src/instrument.ts
+++ b/frontend/src/instrument.ts
@@ -31,7 +31,7 @@ Sentry.init({
     ...(process.env["BASE_URL"] ? [process.env["BASE_URL"]] : []),
   ],
 
-  replaysSessionSampleRate: 1.0,
+  replaysSessionSampleRate: 0.1,
   replaysOnErrorSampleRate: 1.0,
 
   tunnel: `${process.env["BASE_URL"] || ""}/sentry-tunnel/`,

--- a/frontend/src/providers/auth-provider.tsx
+++ b/frontend/src/providers/auth-provider.tsx
@@ -1,5 +1,6 @@
 import {AuthProvider, HttpError, useApiUrl} from "@refinedev/core";
 import axios from "axios";
+import * as Sentry from "@sentry/react";
 import {TokenCreate} from "../types/auth";
 import {ACCESS_TOKEN_KEY, API_URL, REFRESH_TOKEN_KEY} from "../constants";
 import {AuthActionResponse} from "@refinedev/core/dist/contexts/auth/types";
@@ -62,6 +63,8 @@ export const authProvider: AuthProvider = {
   logout: async (props) => {
     localStorage.removeItem(ACCESS_TOKEN_KEY);
     localStorage.removeItem(REFRESH_TOKEN_KEY);
+
+    Sentry.setUser(null);
 
     return {
       success: true,
@@ -148,6 +151,8 @@ export const authProvider: AuthProvider = {
     if (!data) {
       return undefined;
     }
+
+    Sentry.setUser({ id: data.id, email: data.email });
 
     return {
         id: data.id,


### PR DESCRIPTION
## Résumé
- Ajoute `Sentry.setUser({ id, email })` dans `getIdentity` (posé aussi bien après un login qu'après une restauration de session) et `Sentry.setUser(null)` au `logout`, pour lier les erreurs remontées à l'utilisateur connecté.
- Abaisse `replaysSessionSampleRate` de `1.0` à `0.1` pour limiter la consommation du quota Sentry en production (`replaysOnErrorSampleRate` reste à `1.0`, peu coûteux car ne capture qu'en cas d'erreur).

## Test plan
- [ ] Se connecter dans l'app, vérifier dans Sentry (onglet Issues/User) qu'une erreur déclenchée manuellement porte bien l'id + email de l'utilisateur
- [ ] Se déconnecter, vérifier que le contexte utilisateur Sentry est vidé (`Sentry.setUser(null)`)
- [ ] Vérifier dans le dashboard Sentry que les nouveaux replays de session sont bien échantillonnés à ~10%